### PR TITLE
when showing ghost bonus score hide pacman issue89

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -15,7 +15,8 @@ import {
   PACMAN_DEATH_PALETTE_OFFSET_Y,
   PACMAN_DEATH_ANIMATION_FRAMES,
   POWER_UP_FLASH_THRESHOLD,
-  POWER_UP_FLASH_RATE
+  POWER_UP_FLASH_RATE,
+  COLLISION_THRESHOLD
 } from './config.js';
 import { getTileMask } from './autotile.js';
 import {
@@ -385,7 +386,7 @@ export class Renderer implements IRenderer {
 
         // Skip rendering Pacman if we are showing points at this position
         const effects = state.getPointEffects();
-        if (effects.some(e => Math.abs(e.x - entity.x) < 0.1 && Math.abs(e.y - entity.y) < 0.1)) {
+        if (effects.some(e => Math.abs(e.x - entity.x) < COLLISION_THRESHOLD && Math.abs(e.y - entity.y) < COLLISION_THRESHOLD)) {
           return;
         }
 
@@ -466,7 +467,7 @@ export class Renderer implements IRenderer {
 
         // Skip rendering the ghost if it was just eaten and we are showing points
         const effects = state.getPointEffects();
-        if (effects.some(e => Math.abs(e.x - entity.x) < 0.1 && Math.abs(e.y - entity.y) < 0.1)) {
+        if (effects.some(e => Math.abs(e.x - entity.x) < COLLISION_THRESHOLD && Math.abs(e.y - entity.y) < COLLISION_THRESHOLD)) {
           return;
         }
 

--- a/src/repro_issue_89.test.ts
+++ b/src/repro_issue_89.test.ts
@@ -72,10 +72,10 @@ describe('Issue 89: Hide Pacman During Ghost Bonus Score', () => {
     };
   });
 
-  it('should skip rendering Pacman if a point effect is at its position', () => {
+  it('should skip rendering Pacman if a point effect is near its position (within collision threshold)', () => {
     const pacman: Entity = { 
       type: EntityType.Pacman, 
-      x: 5, 
+      x: 5.3, 
       y: 5, 
       direction: { dx: 1, dy: 0 },
       animationFrame: 0
@@ -97,10 +97,10 @@ describe('Issue 89: Hide Pacman During Ghost Bonus Score', () => {
     expect(mockContext.fillText).toHaveBeenCalledWith('200', 5 * TILE_SIZE + TILE_SIZE / 2, 5 * TILE_SIZE + TILE_SIZE / 2);
   });
 
-  it('should skip rendering Pacman (spritesheet) if a point effect is at its position', () => {
+  it('should skip rendering Pacman (spritesheet) if a point effect is near its position', () => {
     const pacman: Entity = { 
       type: EntityType.Pacman, 
-      x: 5, 
+      x: 5.3, 
       y: 5, 
       direction: { dx: 1, dy: 0 },
       animationFrame: 0


### PR DESCRIPTION
- **Hide Pacman when a ghost bonus score is displayed at his position (fixes #89)**
- **fix(test): use Entity type instead of non-existent IPacman in repro_issue_89.test.ts**

Closes https://github.com/gfxblit/prompt-man/issues/89