### PR TITLE
refactor: address PR #101 feedback for EventBus and types

### DIFF
--- a/src/event-bus.test.ts
+++ b/src/event-bus.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from 'vitest';
+import { EventBus } from './event-bus.js';
+import { GameEvent } from './types.js';
+
+describe('EventBus', () => {
+  it('should allow subscribing to and emitting events', () => {
+    const bus = new EventBus();
+    const callback = vi.fn();
+
+    bus.on(GameEvent.PELLET_EATEN, callback);
+    bus.emit(GameEvent.PELLET_EATEN, { tileType: 'Pellet' });
+
+    expect(callback).toHaveBeenCalledWith({ tileType: 'Pellet' });
+  });
+
+  it('should allow unsubscribing from events', () => {
+    const bus = new EventBus();
+    const callback = vi.fn();
+
+    const unsubscribe = bus.on(GameEvent.PELLET_EATEN, callback);
+    unsubscribe();
+    bus.emit(GameEvent.PELLET_EATEN, { tileType: 'Pellet' });
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('should support multiple subscribers for the same event', () => {
+    const bus = new EventBus();
+    const callback1 = vi.fn();
+    const callback2 = vi.fn();
+
+    bus.on(GameEvent.PELLET_EATEN, callback1);
+    bus.on(GameEvent.PELLET_EATEN, callback2);
+    bus.emit(GameEvent.PELLET_EATEN, { tileType: 'Pellet' });
+
+    expect(callback1).toHaveBeenCalled();
+    expect(callback2).toHaveBeenCalled();
+  });
+
+  it('should not affect other events when emitting', () => {
+    const bus = new EventBus();
+    const callback1 = vi.fn();
+    const callback2 = vi.fn();
+
+    bus.on(GameEvent.PELLET_EATEN, callback1);
+    bus.on(GameEvent.GHOST_EATEN, callback2);
+    bus.emit(GameEvent.PELLET_EATEN, { tileType: 'Pellet' });
+
+    expect(callback1).toHaveBeenCalled();
+    expect(callback2).not.toHaveBeenCalled();
+  });
+
+  it('should not throw when emitting an event with no subscribers', () => {
+    const bus = new EventBus();
+    expect(() =>
+      bus.emit(GameEvent.PELLET_EATEN, { tileType: 'Pellet' })
+    ).not.toThrow();
+  });
+});

--- a/src/event-bus.ts
+++ b/src/event-bus.ts
@@ -1,0 +1,49 @@
+import { GameEvent, type EventPayloads } from './types.js';
+
+type Callback<T> = (data: T) => void;
+
+/**
+ * A lightweight, type-safe event bus for decoupled communication between game systems.
+ */
+export class EventBus {
+  private subscribers: { [E in GameEvent]?: Set<Callback<EventPayloads[E]>> } = {};
+
+  /**
+   * Subscribes to an event.
+   * @param event The event to subscribe to.
+   * @param callback The callback to execute when the event is emitted.
+   * @returns A function to unsubscribe.
+   */
+  on<E extends GameEvent>(
+    event: E,
+    callback: Callback<EventPayloads[E]>
+  ): () => void {
+    if (!this.subscribers[event]) {
+      this.subscribers[event] = new Set() as any;
+    }
+    (this.subscribers[event] as unknown as Set<Callback<EventPayloads[E]>>).add(callback);
+
+    return () => {
+      const set = this.subscribers[event];
+      if (set) {
+        (set as unknown as Set<Callback<EventPayloads[E]>>).delete(callback);
+        if (set.size === 0) {
+          delete this.subscribers[event];
+        }
+      }
+    };
+  }
+
+  /**
+   * Emits an event to all subscribers.
+   * @param event The event to emit.
+   * @param data The data to pass to subscribers, matching the event's payload type.
+   */
+  emit<E extends GameEvent>(event: E, data: EventPayloads[E]): void {
+    const set = this.subscribers[event];
+    if (set) {
+      // The type assertion is needed due to a TypeScript limitation with correlated types.
+      (set as unknown as Set<Callback<EventPayloads[E]>>).forEach((cb) => cb(data));
+    }
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -175,6 +175,45 @@ export interface IRenderer {
 }
 
 /**
+ * Represents the current mode of the game state.
+ */
+export enum GameStateMode {
+  READY = 'READY',
+  PLAYING = 'PLAYING',
+  DYING = 'DYING',
+  WIN = 'WIN',
+  GAME_OVER = 'GAME_OVER',
+}
+
+/**
+ * Events that can be emitted by the game engine.
+ */
+export enum GameEvent {
+  PELLET_EATEN = 'PELLET_EATEN',
+  POWER_PELLET_EATEN = 'POWER_PELLET_EATEN',
+  GHOST_EATEN = 'GHOST_EATEN',
+  PACMAN_DEATH = 'PACMAN_DEATH',
+  LEVEL_START = 'LEVEL_START',
+  LEVEL_COMPLETE = 'LEVEL_COMPLETE',
+  GAME_END = 'GAME_END',
+  READY_START = 'READY_START',
+}
+
+/**
+ * Payload definitions for each game event.
+ */
+export interface EventPayloads {
+  [GameEvent.PELLET_EATEN]: { tileType: string };
+  [GameEvent.POWER_PELLET_EATEN]: { x: number; y: number };
+  [GameEvent.GHOST_EATEN]: { points: number };
+  [GameEvent.PACMAN_DEATH]: void;
+  [GameEvent.LEVEL_START]: { level: number };
+  [GameEvent.LEVEL_COMPLETE]: { level: number };
+  [GameEvent.GAME_END]: void;
+  [GameEvent.READY_START]: void;
+}
+
+/**
  * Interface for rendering UI overlays like touch controls.
  */
 export interface IUIRenderer {


### PR DESCRIPTION
Addressed feedback from PR #101.
1. Renamed `GameEvent.GAME_OVER` to `GameEvent.GAME_END`.
2. Added `EventPayloads` interface in `src/types.ts`.
3. Updated `EventBus` to be type-safe using generics and `EventPayloads`.
4. Fixed memory cleanup in `EventBus.on`.
5. Updated `src/event-bus.test.ts` to pass required payloads.
6. Ensured compliance with `verbatimModuleSyntax` and `noImplicitAny` (via explicit casting where necessary).

---
*PR created automatically by Jules for task [11825311606351251507](https://jules.google.com/task/11825311606351251507) started by @gfxblit*