### PR TITLE
Implement fruit transparency by treating black pixels as transparent (issue #113)

### DIFF
--- a/src/renderer.points.test.ts
+++ b/src/renderer.points.test.ts
@@ -10,78 +10,19 @@ import {
   MAZE_RENDER_MARGIN_BOTTOM
 } from './config.js';
 
+import { createMockContext, createMockState, type MockContext } from './test-utils.js';
+
 describe('Renderer Point Effects', () => {
-  let mockContext: {
-    fillRect: ReturnType<typeof vi.fn>;
-    beginPath: ReturnType<typeof vi.fn>;
-    arc: ReturnType<typeof vi.fn>;
-    fill: ReturnType<typeof vi.fn>;
-    clearRect: ReturnType<typeof vi.fn>;
-    lineTo: ReturnType<typeof vi.fn>;
-    closePath: ReturnType<typeof vi.fn>;
-    drawImage: ReturnType<typeof vi.fn>;
-    save: ReturnType<typeof vi.fn>;
-    restore: ReturnType<typeof vi.fn>;
-    translate: ReturnType<typeof vi.fn>;
-    scale: ReturnType<typeof vi.fn>;
-    fillStyle: string;
-    fillText: ReturnType<typeof vi.fn>;
-    font: string;
-    textAlign: string;
-    textBaseline: string;
-    canvas: {
-      width: number;
-      height: number;
-    };
-  };
+  let mockContext: MockContext;
   let mockState: IGameState;
   let renderer: Renderer;
 
   beforeEach(() => {
-    mockContext = {
-      fillRect: vi.fn(),
-      beginPath: vi.fn(),
-      arc: vi.fn(),
-      fill: vi.fn(),
-      clearRect: vi.fn(),
-      lineTo: vi.fn(),
-      closePath: vi.fn(),
-      drawImage: vi.fn(),
-      save: vi.fn(),
-      restore: vi.fn(),
-      translate: vi.fn(),
-      scale: vi.fn(),
-      fillStyle: '',
-      fillText: vi.fn(),
-      font: '',
-      textAlign: '',
-      textBaseline: '',
-      canvas: {
-        width: 10 * TILE_SIZE + MAZE_RENDER_OFFSET_X * 2,
-        height: 10 * TILE_SIZE + MAZE_RENDER_OFFSET_Y + MAZE_RENDER_MARGIN_BOTTOM
-      }
-    };
-    mockState = {
-      getEntities: vi.fn().mockReturnValue([]),
-      getScore: vi.fn().mockReturnValue(0),
-      getHighScore: vi.fn().mockReturnValue(0),
-      getLives: vi.fn().mockReturnValue(0),
-      getRemainingPellets: vi.fn().mockReturnValue(0),
-      getSpawnPosition: vi.fn(),
-      consumePellet: vi.fn(),
-      isPelletEaten: vi.fn().mockReturnValue(false),
-      updatePacman: vi.fn(),
-      updateGhosts: vi.fn(),
-      isGameOver: vi.fn().mockReturnValue(false),
-      isWin: vi.fn().mockReturnValue(false),
-      getLevel: vi.fn().mockReturnValue(1),
-      isDying: vi.fn().mockReturnValue(false),
-      isReady: vi.fn().mockReturnValue(false),
-      getPowerUpTimer: vi.fn().mockReturnValue(0),
-      getPointEffects: vi.fn().mockReturnValue([]),
-      getFruit: vi.fn().mockReturnValue(null),
-      startReady: vi.fn(),
-    };
+    mockContext = createMockContext(
+      10 * TILE_SIZE + MAZE_RENDER_OFFSET_X * 2,
+      10 * TILE_SIZE + MAZE_RENDER_OFFSET_Y + MAZE_RENDER_MARGIN_BOTTOM
+    );
+    mockState = createMockState();
   });
 
   it('should render point effects', () => {

--- a/src/renderer.test.ts
+++ b/src/renderer.test.ts
@@ -12,31 +12,7 @@ import {
   MAZE_RENDER_MARGIN_BOTTOM
 } from './config.js';
 
-interface MockContext {
-  fillRect: ReturnType<typeof vi.fn>;
-  beginPath: ReturnType<typeof vi.fn>;
-  arc: ReturnType<typeof vi.fn>;
-  fill: ReturnType<typeof vi.fn>;
-  clearRect: ReturnType<typeof vi.fn>;
-  lineTo: ReturnType<typeof vi.fn>;
-  closePath: ReturnType<typeof vi.fn>;
-  drawImage: ReturnType<typeof vi.fn>;
-  save: ReturnType<typeof vi.fn>;
-  restore: ReturnType<typeof vi.fn>;
-  translate: ReturnType<typeof vi.fn>;
-  scale: ReturnType<typeof vi.fn>;
-  fillStyle: string;
-  fillText: ReturnType<typeof vi.fn>;
-  font: string;
-  textAlign: string;
-  textBaseline: string;
-  canvas: {
-    width: number;
-    height: number;
-  };
-  _fillStyle: string;
-  fillStyleSpy: ReturnType<typeof vi.fn>;
-}
+import { createMockContext, createMockState, type MockContext } from './test-utils.js';
 
 describe('Renderer', () => {
   let mockContext: MockContext;
@@ -44,57 +20,11 @@ describe('Renderer', () => {
   let renderer: Renderer;
 
   beforeEach(() => {
-    const fillStyleSpy = vi.fn((val: string) => {
-      mockContext._fillStyle = val;
-    });
-
-    mockContext = {
-      fillRect: vi.fn(),
-      beginPath: vi.fn(),
-      arc: vi.fn(),
-      fill: vi.fn(),
-      clearRect: vi.fn(),
-      lineTo: vi.fn(),
-      closePath: vi.fn(),
-      drawImage: vi.fn(),
-      save: vi.fn(),
-      restore: vi.fn(),
-      translate: vi.fn(),
-      scale: vi.fn(),
-      get fillStyle() { return this._fillStyle; },
-      set fillStyle(val) { fillStyleSpy(val); },
-      _fillStyle: '',
-      fillStyleSpy: fillStyleSpy,
-      fillText: vi.fn(),
-      font: '',
-      textAlign: '',
-      textBaseline: '',
-      canvas: {
-        width: 10 * TILE_SIZE + MAZE_RENDER_OFFSET_X * 2,
-        height: 15 * TILE_SIZE + MAZE_RENDER_OFFSET_Y + MAZE_RENDER_MARGIN_BOTTOM
-      }
-    };
-    mockState = {
-      getEntities: vi.fn().mockReturnValue([]),
-      getScore: vi.fn().mockReturnValue(0),
-      getHighScore: vi.fn().mockReturnValue(0),
-      getLives: vi.fn().mockReturnValue(0),
-      getRemainingPellets: vi.fn().mockReturnValue(0),
-      getSpawnPosition: vi.fn(),
-      consumePellet: vi.fn(),
-      isPelletEaten: vi.fn().mockReturnValue(false),
-      updatePacman: vi.fn(),
-      updateGhosts: vi.fn(),
-      isGameOver: vi.fn().mockReturnValue(false),
-      isWin: vi.fn().mockReturnValue(false),
-      getLevel: vi.fn().mockReturnValue(1),
-      isDying: vi.fn().mockReturnValue(false),
-      isReady: vi.fn().mockReturnValue(false),
-      getPowerUpTimer: vi.fn().mockReturnValue(0),
-      getPointEffects: vi.fn().mockReturnValue([]),
-      getFruit: vi.fn().mockReturnValue(null),
-      startReady: vi.fn(),
-    };
+    mockContext = createMockContext(
+      10 * TILE_SIZE + MAZE_RENDER_OFFSET_X * 2,
+      15 * TILE_SIZE + MAZE_RENDER_OFFSET_Y + MAZE_RENDER_MARGIN_BOTTOM
+    );
+    mockState = createMockState();
 
     // Mock document.createElement for canvas
     const mockCanvas = {

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -39,7 +39,7 @@ import {
 import { getHudFruits } from './hud-fruits.js';
 
 export class Renderer implements IRenderer {
-  private ghostCache = new Map<string, HTMLCanvasElement>();
+  private spriteCache = new Map<string, HTMLCanvasElement>();
 
   constructor(
     private ctx: CanvasRenderingContext2D,
@@ -118,8 +118,7 @@ export class Renderer implements IRenderer {
         const x = startX - rightIndex * gap;
         const y = startY + TILE_SIZE / 2; // Center Y
 
-        this.ctx.drawImage(
-            this.spritesheet,
+        this.renderWithTransparentBlack(
             offset.x + PALETTE_PADDING_X,
             offset.y + PALETTE_PADDING_Y,
             SOURCE_FRUIT_SIZE - PALETTE_PADDING_X,
@@ -381,10 +380,10 @@ export class Renderer implements IRenderer {
   }
 
   /**
-   * Renders a ghost sprite with black pixels made transparent.
-   * Used for rendering dead ghost eyes without the black background.
+   * Renders a sprite with black pixels made transparent.
+   * Used for rendering sprites without the black background.
    */
-  private renderGhostWithTransparentBlack(
+  private renderWithTransparentBlack(
     sourceX: number,
     sourceY: number,
     sourceWidth: number,
@@ -397,7 +396,7 @@ export class Renderer implements IRenderer {
     if (!this.spritesheet) return;
 
     const cacheKey = `${sourceX},${sourceY},${sourceWidth},${sourceHeight}`;
-    let tempCanvas = this.ghostCache.get(cacheKey);
+    let tempCanvas = this.spriteCache.get(cacheKey);
 
     if (!tempCanvas) {
       // Create a temporary canvas to extract and modify the sprite
@@ -440,7 +439,7 @@ export class Renderer implements IRenderer {
       tempCtx.putImageData(imageData, 0, 0);
 
       // Store in cache
-      this.ghostCache.set(cacheKey, tempCanvas);
+      this.spriteCache.set(cacheKey, tempCanvas);
     }
 
     // Draw the modified sprite to the main canvas
@@ -587,7 +586,7 @@ export class Renderer implements IRenderer {
           this.ctx.scale(scaleX, scaleY);
 
           // For all ghosts, make black pixels transparent
-          this.renderGhostWithTransparentBlack(
+          this.renderWithTransparentBlack(
             spriteSource.x,
             spriteSource.y,
             spriteSource.width,
@@ -638,8 +637,7 @@ export class Renderer implements IRenderer {
         if (this.spritesheet && entity.fruitType) {
           const offset = FRUIT_OFFSETS[entity.fruitType];
           if (offset) {
-            this.ctx.drawImage(
-              this.spritesheet,
+            this.renderWithTransparentBlack(
               offset.x + PALETTE_PADDING_X,
               offset.y + PALETTE_PADDING_Y,
               SOURCE_FRUIT_SIZE - PALETTE_PADDING_X,

--- a/src/repro_issue_108.test.ts
+++ b/src/repro_issue_108.test.ts
@@ -120,6 +120,7 @@ describe('Renderer Ghost Transparency (Issue #108)', () => {
     // Normal ghost
     const entities: Partial<Entity>[] = [{ type: EntityType.Ghost, x: 0, y: 0, color: 'red', animationFrame: 0 }];
     vi.mocked(mockState.getEntities).mockReturnValue(entities as Entity[]);
+    vi.mocked(mockState.getLevel).mockReturnValue(0);
 
     // First render
     renderer.render(grid, mockState);

--- a/src/repro_issue_108.test.ts
+++ b/src/repro_issue_108.test.ts
@@ -4,70 +4,16 @@ import { Grid } from './grid.js';
 import { EntityType } from './types.js';
 import type { IGameState, Entity } from './types.js';
 
+import { createMockContext, createMockState, type MockContext } from './test-utils.js';
+
 describe('Renderer Ghost Transparency (Issue #108)', () => {
-  let mockContext: {
-    fillRect: ReturnType<typeof vi.fn>;
-    beginPath: ReturnType<typeof vi.fn>;
-    arc: ReturnType<typeof vi.fn>;
-    fill: ReturnType<typeof vi.fn>;
-    clearRect: ReturnType<typeof vi.fn>;
-    lineTo: ReturnType<typeof vi.fn>;
-    closePath: ReturnType<typeof vi.fn>;
-    drawImage: ReturnType<typeof vi.fn>;
-    save: ReturnType<typeof vi.fn>;
-    restore: ReturnType<typeof vi.fn>;
-    translate: ReturnType<typeof vi.fn>;
-    scale: ReturnType<typeof vi.fn>;
-    fillStyle: string;
-    fillText: ReturnType<typeof vi.fn>;
-    font: string;
-    textAlign: string;
-    textBaseline: string;
-  };
+  let mockContext: MockContext;
   let mockState: IGameState;
   let renderer: Renderer;
 
   beforeEach(() => {
-    mockContext = {
-      fillRect: vi.fn(),
-      beginPath: vi.fn(),
-      arc: vi.fn(),
-      fill: vi.fn(),
-      clearRect: vi.fn(),
-      lineTo: vi.fn(),
-      closePath: vi.fn(),
-      drawImage: vi.fn(),
-      save: vi.fn(),
-      restore: vi.fn(),
-      translate: vi.fn(),
-      scale: vi.fn(),
-      fillStyle: '',
-      fillText: vi.fn(),
-      font: '',
-      textAlign: '',
-      textBaseline: '',
-    };
-    mockState = {
-      getEntities: vi.fn().mockReturnValue([]),
-      getScore: vi.fn().mockReturnValue(0),
-      getHighScore: vi.fn().mockReturnValue(0),
-      getLives: vi.fn().mockReturnValue(0),
-      getRemainingPellets: vi.fn().mockReturnValue(0),
-      getSpawnPosition: vi.fn(),
-      consumePellet: vi.fn(),
-      isPelletEaten: vi.fn().mockReturnValue(false),
-      updatePacman: vi.fn(),
-      updateGhosts: vi.fn(),
-      isGameOver: vi.fn().mockReturnValue(false),
-      isWin: vi.fn().mockReturnValue(false),
-      getLevel: vi.fn().mockReturnValue(1),
-      isDying: vi.fn().mockReturnValue(false),
-      isReady: vi.fn().mockReturnValue(false),
-      getPowerUpTimer: vi.fn().mockReturnValue(0),
-      getPointEffects: vi.fn().mockReturnValue([]),
-      getFruit: vi.fn().mockReturnValue(null),
-      startReady: vi.fn(),
-    };
+    mockContext = createMockContext(0, 0); // Use grid-based fallback
+    mockState = createMockState();
 
     // Mock document.createElement for canvas
     const mockCanvas = {

--- a/src/repro_issue_113.test.ts
+++ b/src/repro_issue_113.test.ts
@@ -1,15 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Renderer } from './renderer.js';
 import { Grid } from './grid.js';
+import { EntityType, FruitType } from './types.js';
 import type { IGameState } from './types.js';
 import {
   TILE_SIZE,
   MAZE_RENDER_OFFSET_X,
   MAZE_RENDER_OFFSET_Y,
   MAZE_RENDER_MARGIN_BOTTOM,
-  PALETTE_PADDING_X,
-  PALETTE_PADDING_Y,
-  SOURCE_FRUIT_SIZE
 } from './config.js';
 
 interface MockContext {
@@ -38,7 +36,7 @@ interface MockContext {
   fillStyleSpy: ReturnType<typeof vi.fn>;
 }
 
-describe('Renderer HUD Fruits', () => {
+describe('Issue #113: Fruit Transparency Reproduction', () => {
   let mockContext: MockContext;
   let mockState: IGameState;
   let renderer: Renderer;
@@ -97,7 +95,10 @@ describe('Renderer HUD Fruits', () => {
       startReady: vi.fn(),
     };
 
-    mockSpritesheet = {} as HTMLImageElement;
+    mockSpritesheet = {
+        width: 256,
+        height: 256
+    } as HTMLImageElement;
 
     // Mock document.createElement for canvas
     const mockCanvas = {
@@ -116,53 +117,53 @@ describe('Renderer HUD Fruits', () => {
     });
   });
 
-  it('should render fruits in HUD for Level 2 (Cherry, Strawberry)', () => {
+  it('should render fruits on board using transparency cache (canvas instead of spritesheet)', () => {
     renderer = new Renderer(mockContext as unknown as CanvasRenderingContext2D, mockSpritesheet);
     const grid = new Grid(10, 10);
-    vi.mocked(mockState.getLevel).mockReturnValue(2);
+    
+    vi.mocked(mockState.getEntities).mockReturnValue([{
+      type: EntityType.Fruit,
+      fruitType: FruitType.Cherry,
+      x: 5,
+      y: 5
+    }]);
 
     renderer.render(grid, mockState);
 
-    // Expect drawImage to be called for Cherry and Strawberry
-
-    // Check for Cherry draw call
-    expect(mockContext.drawImage).toHaveBeenCalledWith(
-      expect.anything(),
-      0, // sourceX (from canvas)
-      0, // sourceY (from canvas)
-      SOURCE_FRUIT_SIZE - PALETTE_PADDING_X,
-      SOURCE_FRUIT_SIZE - PALETTE_PADDING_Y,
-      expect.any(Number), // destX
-      expect.any(Number), // destY
-      TILE_SIZE,
-      TILE_SIZE
+    // Should NOT call drawImage with mockSpritesheet for the fruit
+    // It should call it with an HTMLCanvasElement (the cache)
+    const drawImageCalls = mockContext.drawImage.mock.calls;
+    const fruitDrawCall = drawImageCalls.find(call => 
+        call[5] === 5 * TILE_SIZE + TILE_SIZE / 2 + MAZE_RENDER_OFFSET_X - TILE_SIZE / 2 &&
+        call[6] === 5 * TILE_SIZE + TILE_SIZE / 2 + MAZE_RENDER_OFFSET_Y - TILE_SIZE / 2
     );
 
-    // Check for Strawberry draw call
-    expect(mockContext.drawImage).toHaveBeenCalledWith(
-      expect.anything(),
-      0, // sourceX (from canvas)
-      0, // sourceY (from canvas)
-      SOURCE_FRUIT_SIZE - PALETTE_PADDING_X,
-      SOURCE_FRUIT_SIZE - PALETTE_PADDING_Y,
-      expect.any(Number), // destX
-      expect.any(Number), // destY
-      TILE_SIZE,
-      TILE_SIZE
-    );
+    expect(fruitDrawCall).toBeDefined();
+    expect(fruitDrawCall![0]).not.toBe(mockSpritesheet);
+    expect(fruitDrawCall![0].constructor.name).toBe('Object'); // Our mocked canvas is an object
   });
-  
-  it('should not render fruits if spritesheet is missing', () => {
-      renderer = new Renderer(mockContext as unknown as CanvasRenderingContext2D, undefined);
-      const grid = new Grid(10, 10);
-      vi.mocked(mockState.getLevel).mockReturnValue(2);
-      
-      renderer.render(grid, mockState);
-      
-      // Should not call drawImage for fruits (or at all if no other sprites)
-      // Since getEntities returns [], only walls/pellets might be drawn.
-      // But walls/pellets use rects if no spritesheet.
-      // So drawImage should not be called.
-      expect(mockContext.drawImage).not.toHaveBeenCalled();
+
+  it('should render fruits in HUD using transparency cache (canvas instead of spritesheet)', () => {
+    renderer = new Renderer(mockContext as unknown as CanvasRenderingContext2D, mockSpritesheet);
+    const grid = new Grid(10, 10);
+    vi.mocked(mockState.getLevel).mockReturnValue(1); // Level 1 has Cherry
+
+    renderer.render(grid, mockState);
+
+    // Find the HUD fruit draw call. It should be near the bottom right.
+    const drawImageCalls = mockContext.drawImage.mock.calls;
+    
+    // We expect at least one drawImage call for the HUD fruit
+    // HUD fruits are rendered after tiles and entities.
+    // Cherry offset is {x: 0, y: 144} (from config.ts)
+    
+    const hudFruitCall = drawImageCalls.find(call => 
+        call[0] !== mockSpritesheet && 
+        call[5] > 100 && // destX
+        call[6] > 100    // destY
+    );
+
+    expect(hudFruitCall).toBeDefined();
+    expect(hudFruitCall![0]).not.toBe(mockSpritesheet);
   });
 });

--- a/src/repro_issue_113.test.ts
+++ b/src/repro_issue_113.test.ts
@@ -9,32 +9,7 @@ import {
   MAZE_RENDER_OFFSET_Y,
   MAZE_RENDER_MARGIN_BOTTOM,
 } from './config.js';
-
-interface MockContext {
-  fillRect: ReturnType<typeof vi.fn>;
-  beginPath: ReturnType<typeof vi.fn>;
-  arc: ReturnType<typeof vi.fn>;
-  fill: ReturnType<typeof vi.fn>;
-  clearRect: ReturnType<typeof vi.fn>;
-  lineTo: ReturnType<typeof vi.fn>;
-  closePath: ReturnType<typeof vi.fn>;
-  drawImage: ReturnType<typeof vi.fn>;
-  save: ReturnType<typeof vi.fn>;
-  restore: ReturnType<typeof vi.fn>;
-  translate: ReturnType<typeof vi.fn>;
-  scale: ReturnType<typeof vi.fn>;
-  fillStyle: string;
-  fillText: ReturnType<typeof vi.fn>;
-  font: string;
-  textAlign: string;
-  textBaseline: string;
-  canvas: {
-    width: number;
-    height: number;
-  };
-  _fillStyle: string;
-  fillStyleSpy: ReturnType<typeof vi.fn>;
-}
+import { createMockContext, createMockState, type MockContext } from './test-utils.js';
 
 describe('Issue #113: Fruit Transparency Reproduction', () => {
   let mockContext: MockContext;
@@ -43,57 +18,11 @@ describe('Issue #113: Fruit Transparency Reproduction', () => {
   let mockSpritesheet: HTMLImageElement;
 
   beforeEach(() => {
-    const fillStyleSpy = vi.fn((val: string) => {
-      mockContext._fillStyle = val;
-    });
-
-    mockContext = {
-      fillRect: vi.fn(),
-      beginPath: vi.fn(),
-      arc: vi.fn(),
-      fill: vi.fn(),
-      clearRect: vi.fn(),
-      lineTo: vi.fn(),
-      closePath: vi.fn(),
-      drawImage: vi.fn(),
-      save: vi.fn(),
-      restore: vi.fn(),
-      translate: vi.fn(),
-      scale: vi.fn(),
-      get fillStyle() { return this._fillStyle; },
-      set fillStyle(val) { fillStyleSpy(val); },
-      _fillStyle: '',
-      fillStyleSpy: fillStyleSpy,
-      fillText: vi.fn(),
-      font: '',
-      textAlign: '',
-      textBaseline: '',
-      canvas: {
-        width: 10 * TILE_SIZE + MAZE_RENDER_OFFSET_X * 2,
-        height: 15 * TILE_SIZE + MAZE_RENDER_OFFSET_Y + MAZE_RENDER_MARGIN_BOTTOM
-      }
-    };
-    mockState = {
-      getEntities: vi.fn().mockReturnValue([]),
-      getScore: vi.fn().mockReturnValue(0),
-      getHighScore: vi.fn().mockReturnValue(0),
-      getLives: vi.fn().mockReturnValue(0),
-      getRemainingPellets: vi.fn().mockReturnValue(0),
-      getSpawnPosition: vi.fn(),
-      consumePellet: vi.fn(),
-      isPelletEaten: vi.fn().mockReturnValue(false),
-      updatePacman: vi.fn(),
-      updateGhosts: vi.fn(),
-      isGameOver: vi.fn().mockReturnValue(false),
-      isWin: vi.fn().mockReturnValue(false),
-      getLevel: vi.fn().mockReturnValue(1),
-      isDying: vi.fn().mockReturnValue(false),
-      isReady: vi.fn().mockReturnValue(false),
-      getPowerUpTimer: vi.fn().mockReturnValue(0),
-      getPointEffects: vi.fn().mockReturnValue([]),
-      getFruit: vi.fn().mockReturnValue(null),
-      startReady: vi.fn(),
-    };
+    mockContext = createMockContext(
+      10 * TILE_SIZE + MAZE_RENDER_OFFSET_X * 2,
+      15 * TILE_SIZE + MAZE_RENDER_OFFSET_Y + MAZE_RENDER_MARGIN_BOTTOM
+    );
+    mockState = createMockState();
 
     mockSpritesheet = {
         width: 256,
@@ -155,7 +84,7 @@ describe('Issue #113: Fruit Transparency Reproduction', () => {
     
     // We expect at least one drawImage call for the HUD fruit
     // HUD fruits are rendered after tiles and entities.
-    // Cherry offset is {x: 0, y: 144} (from config.ts)
+    // Cherry offset is { x: 600, y: 488 } (from config.ts)
     
     const hudFruitCall = drawImageCalls.find(call => 
         call[0] !== mockSpritesheet && 

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -146,3 +146,89 @@ export function mock2dContext(): CanvasRenderingContext2D {
     set lineWidth(value: number) { /* do nothing */ },
   } as unknown as CanvasRenderingContext2D;
 }
+
+export interface MockContext {
+  fillRect: ReturnType<typeof vi.fn>;
+  beginPath: ReturnType<typeof vi.fn>;
+  arc: ReturnType<typeof vi.fn>;
+  fill: ReturnType<typeof vi.fn>;
+  clearRect: ReturnType<typeof vi.fn>;
+  lineTo: ReturnType<typeof vi.fn>;
+  closePath: ReturnType<typeof vi.fn>;
+  drawImage: ReturnType<typeof vi.fn>;
+  save: ReturnType<typeof vi.fn>;
+  restore: ReturnType<typeof vi.fn>;
+  translate: ReturnType<typeof vi.fn>;
+  scale: ReturnType<typeof vi.fn>;
+  fillStyle: string;
+  fillText: ReturnType<typeof vi.fn>;
+  font: string;
+  textAlign: string;
+  textBaseline: string;
+  canvas: {
+    width: number;
+    height: number;
+  };
+  _fillStyle: string;
+  fillStyleSpy: ReturnType<typeof vi.fn>;
+}
+
+export function createMockContext(width: number, height: number): MockContext {
+  const mockContext = {
+    fillRect: vi.fn(),
+    beginPath: vi.fn(),
+    arc: vi.fn(),
+    fill: vi.fn(),
+    clearRect: vi.fn(),
+    lineTo: vi.fn(),
+    closePath: vi.fn(),
+    drawImage: vi.fn(),
+    save: vi.fn(),
+    restore: vi.fn(),
+    translate: vi.fn(),
+    scale: vi.fn(),
+    _fillStyle: '',
+    get fillStyle(): string { return this._fillStyle; },
+    set fillStyle(val: string) { 
+      this._fillStyle = val;
+      this.fillStyleSpy(val);
+    },
+    fillStyleSpy: vi.fn(),
+    fillText: vi.fn(),
+    font: '',
+    textAlign: '',
+    textBaseline: '',
+    canvas: {
+      width,
+      height
+    }
+  };
+
+  return mockContext as unknown as MockContext;
+}
+
+import type { IGameState } from './types.js';
+
+export function createMockState(): IGameState {
+  return {
+    getEntities: vi.fn().mockReturnValue([]),
+    getScore: vi.fn().mockReturnValue(0),
+    getHighScore: vi.fn().mockReturnValue(0),
+    getLives: vi.fn().mockReturnValue(0),
+    getRemainingPellets: vi.fn().mockReturnValue(0),
+    getSpawnPosition: vi.fn(),
+    consumePellet: vi.fn(),
+    isPelletEaten: vi.fn().mockReturnValue(false),
+    updatePacman: vi.fn(),
+    updateGhosts: vi.fn(),
+    isGameOver: vi.fn().mockReturnValue(false),
+    isWin: vi.fn().mockReturnValue(false),
+    getLevel: vi.fn().mockReturnValue(1),
+    isDying: vi.fn().mockReturnValue(false),
+    isReady: vi.fn().mockReturnValue(false),
+    getPowerUpTimer: vi.fn().mockReturnValue(0),
+    getPointEffects: vi.fn().mockReturnValue([]),
+    getFruit: vi.fn().mockReturnValue(null),
+    startReady: vi.fn(),
+  } as unknown as IGameState;
+}


### PR DESCRIPTION
- Generalized transparency logic in Renderer by renaming ghostCache to spriteCache and renderGhostWithTransparentBlack to renderWithTransparentBlack.
- Applied transparency to fruits on the game board and in the HUD.
- Updated existing tests to expect rendering from cached canvas.
- Added reproduction tests for fruit transparency.

Closes https://github.com/gfxblit/prompt-man/issues/113